### PR TITLE
Move `password` to `settings` again

### DIFF
--- a/apps/api/src/handlers/document/createDocument.ts
+++ b/apps/api/src/handlers/document/createDocument.ts
@@ -207,7 +207,6 @@ export const createDocument: FastifyImp<
       id: createdDocument.id,
       // Use the content from the body, not the database, as the database content is (sometimes) encrypted
       content: body.data.content,
-      password,
       creator: request.user
         ? {
             id: request.user.id,
@@ -230,6 +229,7 @@ export const createDocument: FastifyImp<
         instant_delete: createdDocument.settings.instant_delete,
         encrypted: createdDocument.settings.encrypted,
         public: createdDocument.settings.public,
+        password: password ?? undefined,
         editors,
       },
     },

--- a/apps/api/src/handlers/document/createDocument.ts
+++ b/apps/api/src/handlers/document/createDocument.ts
@@ -207,6 +207,7 @@ export const createDocument: FastifyImp<
       id: createdDocument.id,
       // Use the content from the body, not the database, as the database content is (sometimes) encrypted
       content: body.data.content,
+      password,
       creator: request.user
         ? {
             id: request.user.id,

--- a/apps/bot/src/commands/documents/createDocument.ts
+++ b/apps/bot/src/commands/documents/createDocument.ts
@@ -126,11 +126,11 @@ export const createDocument: Command = {
               inline: true,
             },
           ].concat(
-            document.settings.encrypted && document.password
+            document.settings.encrypted && document.settings.password
               ? [
                   {
                     name: "Password",
-                    value: document.password,
+                    value: document.settings.password,
                     inline: false,
                   },
                 ]


### PR DESCRIPTION
According to the docs the `password` field is supposed to be returned within the `settings` field, but for some reason when creating Documents it was **returned** in the `data` field instead.
As the `password` field is **supplied** within the `settings` field when creating documents I think that this is also the place it should be returned within.

I haven't tested this change completely, and am not entirely familiar with the codebase yet, and therefore am not sure if I missed a spot that uses the document password field via a weird way that I did not find.

Also apologies for creating so many PRs, but I rather separate my changes as to ensure 1 conflict / gripe doesn't prevent all other changes from being merged 