### PR TITLE
Improve User Profile layout on mobile devices

### DIFF
--- a/apps/web/src/components/Dropdown.tsx
+++ b/apps/web/src/components/Dropdown.tsx
@@ -52,7 +52,6 @@ const DropdownButton = styled("button", {
   whiteSpace: "nowrap",
   padding: "5px 10px",
   fontWeight: 500,
-  width: "-webkit-fill-available",
   background: "transparent",
   gap: 10,
   outline: "none",

--- a/apps/web/src/components/Dropdown.tsx
+++ b/apps/web/src/components/Dropdown.tsx
@@ -52,6 +52,7 @@ const DropdownButton = styled("button", {
   whiteSpace: "nowrap",
   padding: "5px 10px",
   fontWeight: 500,
+  width: "-webkit-fill-available",
   background: "transparent",
   gap: 10,
   outline: "none",

--- a/apps/web/src/components/Setting.tsx
+++ b/apps/web/src/components/Setting.tsx
@@ -98,7 +98,11 @@ function Setting<T = "switch" | "dropdown", K = unknown>({
 
       {/* Dropdowns */}
       {type === "dropdown" ? (
-        <Dropdown items={items ?? []} onSelect={(item) => onSelect && onSelect(item)} />
+        <Dropdown
+          style={{ minWidth: 82 }}
+          items={items ?? []}
+          onSelect={(item) => onSelect?.(item)}
+        />
       ) : null}
     </SettingContainer>
   );

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled("div", {
   width: "80%",
   maxWidth: "800px",
   minHeight: "200px",
-  height: "50%",
+  height: "60%",
   maxHeight: "80%",
   background: "$primary800",
   borderRadius: "10px",
@@ -42,12 +42,15 @@ const Container = styled("div", {
   width: "100%",
   height: "100%",
   alignSelf: "baseline",
+  "@media (max-width: 680px)": {
+    flexDirection: "column",
+  },
 });
 
 const Overview = styled("div", {
   display: "flex",
   flexDirection: "column",
-  width: "80%",
+  width: "100%",
   background: "$primary800",
   boxShadow: "-1px 6px 36px 8px rgba(0, 0, 0, 0.25)",
   padding: "20px",
@@ -63,6 +66,10 @@ const Overview = styled("div", {
   "& > *:last-child": {
     marginTop: "auto",
     alignSelf: "flex-start",
+  },
+
+  "@media (max-width: 680px)": {
+    height: "50%",
   },
 });
 
@@ -219,6 +226,10 @@ const Settings = styled("div", {
   flexGrow: 1,
   padding: 20,
   overflow: "auto",
+  width: "100%",
+  "@media (max-width: 680px)": {
+    height: "50%",
+  },
 });
 
 const InputWrapper = styled("div", {

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -34,7 +34,7 @@ const Wrapper = styled("div", {
   maxHeight: "80%",
   background: "$primary800",
   borderRadius: "10px",
-  overflow: "hidden",
+  overflow: "auto",
 });
 
 const Container = styled("div", {
@@ -42,6 +42,7 @@ const Container = styled("div", {
   width: "100%",
   height: "100%",
   alignSelf: "baseline",
+
   "@media (max-width: 680px)": {
     flexDirection: "column",
   },
@@ -69,7 +70,9 @@ const Overview = styled("div", {
   },
 
   "@media (max-width: 680px)": {
-    height: "50%",
+    height: "unset",
+    boxShadow: "unset",
+    overflow: "unset",
   },
 });
 
@@ -227,8 +230,10 @@ const Settings = styled("div", {
   padding: 20,
   overflow: "auto",
   width: "100%",
+
   "@media (max-width: 680px)": {
-    height: "50%",
+    height: "unset",
+    overflow: "unset",
   },
 });
 

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -11,7 +11,7 @@ import { styled } from "@web/stitches.config";
 import { Document, SelfUser, UserSettings as UserSettingsType } from "@web/types";
 import { makeRequest } from "@web/utils/rest";
 import Link from "next/link";
-import { getRole } from "../../utils/permissions";
+import { getRole } from "@web/utils/permissions";
 import Button from "../Button";
 import { DiscordLogo, GitHubLogo } from "../Icons";
 import Input from "../Input";

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -715,7 +715,7 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
               },
               {
                 title: "7 days",
-                value: 2,
+                value: 7,
                 selected: user.settings.expiration === 7,
               },
               {


### PR DESCRIPTION
Before(s)
![image](https://github.com/imperialbin/imperial/assets/51767230/50a81a10-994a-4369-8045-5a7e8bf384e0)
![image](https://github.com/imperialbin/imperial/assets/51767230/ed20fc3b-ffa7-4560-9ba6-078033d7bf8b)

After(s)
![image](https://github.com/imperialbin/imperial/assets/51767230/b480f59b-a29e-4e92-ac0c-ae67d430d488)
![image](https://github.com/imperialbin/imperial/assets/51767230/b312b9af-373b-4076-b626-1c84c91d895e)



- Made the 2 elements stacked on mobile views
- Show contents of buttons when possible (No more `N...` now it's `Never` 😄 )