### PR TITLE
fix(web): raw document button not refreshing

### DIFF
--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -450,8 +450,7 @@ function Nav({ user, document, language, dispatch, editors }: INavProps) {
               <StyledTooltip title="View raw">
                 <Button
                   onClick={() => {
-                    router.push(`/r/${document.id}`);
-                    router.reload();
+                    window.location.href = `/r/${document.id}`;
                   }}
                 >
                   <AlignLeft size={20} />

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -448,7 +448,12 @@ function Nav({ user, document, language, dispatch, editors }: INavProps) {
 
               {/* Raw document button */}
               <StyledTooltip title="View raw">
-                <Button onClick={() => router.push(`/r/${document.id}`)}>
+                <Button
+                  onClick={() => {
+                    router.push(`/r/${document.id}`);
+                    router.reload();
+                  }}
+                >
                   <AlignLeft size={20} />
                 </Button>
               </StyledTooltip>

--- a/apps/web/src/pages/r/[id].tsx
+++ b/apps/web/src/pages/r/[id].tsx
@@ -14,9 +14,7 @@ export const getServerSideProps: GetServerSideProps = async ({ res, params }) =>
   }
 
   return {
-    props: {
-      res,
-    },
+    props: {},
   };
 };
 

--- a/apps/web/src/pages/r/[id].tsx
+++ b/apps/web/src/pages/r/[id].tsx
@@ -14,7 +14,9 @@ export const getServerSideProps: GetServerSideProps = async ({ res, params }) =>
   }
 
   return {
-    props: {},
+    props: {
+      res,
+    },
   };
 };
 


### PR DESCRIPTION
Fix an issue where `/r/:document_id` would not return any data.