### PR TITLE
misc: throw smaller error when token is not provided

### DIFF
--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -14,6 +14,9 @@ const client = new Client({
   intents: [],
 });
 
+if(!env.DISCORD_BOT_TOKEN) {
+  throw "No discord bot token has been provided."
+}
 client.login(env.DISCORD_BOT_TOKEN);
 
 client.on("ready", async (client) => {


### PR DESCRIPTION
This change is mainly so when starting a new development environment the normal stacktrace for not having a discord bot token is not thrown and instead we get this smaller message, it may also be beneficial to check if we're in a production environment to log to a sentry instance.