### PR TITLE
feat(web): switch url type to dropdown

### DIFF
--- a/apps/web/src/components/Dropdown.tsx
+++ b/apps/web/src/components/Dropdown.tsx
@@ -90,7 +90,7 @@ const DropdownButton = styled("button", {
   },
 });
 
-type Item<T> = {
+export type DropdownItem<T> = {
   selected?: boolean;
   value: T;
   title: string;
@@ -99,10 +99,10 @@ type Item<T> = {
 
 export interface IDropdownProps<T> {
   placement?: Placement;
-  items: Item<T>[];
+  items: DropdownItem<T>[];
 
   // eslint-disable-next-line no-unused-vars
-  onSelect: (item: Item<T>) => unknown;
+  onSelect: (item: DropdownItem<T>) => unknown;
   notSelectedOverride?: string;
 
   /* Optional parameter to automatically set width to targets width */
@@ -129,11 +129,11 @@ function Dropdown<T>({
   disabled = false,
 }: IDropdownProps<T>) {
   const [active, setActive] = useState(false);
-  const [selected, setSelected] = useState<Item<T> | null>(
+  const [selected, setSelected] = useState<DropdownItem<T> | null>(
     items.find((item) => item.selected) ?? null,
   );
 
-  const stableSetSelected = useCallback((item: Item<T>) => setSelected(item), []);
+  const stableSetSelected = useCallback((item: DropdownItem<T>) => setSelected(item), []);
 
   // Update the selected item if items changes through props
   useEffect(() => {

--- a/apps/web/src/components/Setting.tsx
+++ b/apps/web/src/components/Setting.tsx
@@ -45,6 +45,8 @@ type SettingProps<T = "dropdown" | "switch", k = unknown> = T extends "switch"
 
       onSelect?: never;
       items?: never;
+
+      minWidth?: never;
     }
   : {
       title: string;
@@ -57,6 +59,8 @@ type SettingProps<T = "dropdown" | "switch", k = unknown> = T extends "switch"
 
       toggled?: never;
       onToggle?: never;
+
+      minWidth?: number;
     };
 
 function Setting<T = "switch" | "dropdown", K = unknown>({
@@ -78,6 +82,8 @@ function Setting<T = "switch" | "dropdown", K = unknown>({
   onSelect,
 
   items,
+
+  minWidth,
 }: SettingProps<T, K>): JSX.Element {
   return (
     <SettingContainer>
@@ -105,7 +111,7 @@ function Setting<T = "switch" | "dropdown", K = unknown>({
       {/* Dropdowns */}
       {type === "dropdown" ? (
         <Dropdown
-          style={{ minWidth: 82 }}
+          style={{ minWidth: minWidth ?? 82 }}
           items={items ?? []}
           onSelect={(item) => onSelect?.(item)}
         />

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -20,7 +20,7 @@ import { addNotification, openModal, setUser } from "@web/state/actions";
 import { ImperialState } from "@web/state/reducers";
 import { styled } from "@web/stitches.config";
 import { Document, SelfUser, UserSettings as UserSettingsType } from "@web/types";
-import { ImperialAPIResponse, ImperialError, makeRequest } from "@web/utils/rest";
+import { makeRequest } from "@web/utils/rest";
 import Link from "next/link";
 import { getRole } from "@web/utils/permissions";
 import Button from "../Button";
@@ -364,15 +364,13 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
     });
 
     if (!success || !data) {
-      dispatch(
+      return dispatch(
         addNotification({
           icon: <X />,
           message: error?.message ?? "An unknown error occurred",
           type: "error",
         }),
       );
-
-      return false;
     }
 
     dispatch(
@@ -476,17 +474,23 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
     const { value } = item;
     const settings = user.settings;
 
-    const updates: { short_urls: boolean | undefined; long_urls: boolean | undefined } = {
+    const updates: {
+      short_urls: boolean | undefined;
+      long_urls: boolean | undefined;
+    } = {
       short_urls: undefined,
       long_urls: undefined,
     };
 
+    // set to short
     if (value === "short") {
       updates.short_urls = true;
 
+      // fix legacy settings
       if (settings.long_urls) {
         updates.long_urls = false;
       }
+      // set to 8 characters
     } else if (value === "normal") {
       if (settings.short_urls) {
         updates.short_urls = false;
@@ -495,9 +499,11 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
       if (settings.long_urls) {
         updates.long_urls = false;
       }
+      // set to long
     } else if (value === "long") {
       updates.long_urls = true;
 
+      // fix legacy settings
       if (settings.short_urls) {
         updates.short_urls = false;
       }

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -474,43 +474,28 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
     const { value } = item;
     const settings = user.settings;
 
-    const updates: {
-      short_urls: boolean | undefined;
-      long_urls: boolean | undefined;
-    } = {
-      short_urls: undefined,
-      long_urls: undefined,
-    };
+    let payload: Pick<Partial<UserSettingsType>, "short_urls" | "long_urls"> = {};
 
-    // set to short
     if (value === "short") {
-      updates.short_urls = true;
-
-      // fix legacy settings
-      if (settings.long_urls) {
-        updates.long_urls = false;
-      }
-      // set to 8 characters
+      payload = {
+        short_urls: true,
+        long_urls: settings.long_urls ? false : undefined,
+      };
     } else if (value === "normal") {
-      if (settings.short_urls) {
-        updates.short_urls = false;
-      }
-
-      if (settings.long_urls) {
-        updates.long_urls = false;
-      }
-      // set to long
+      payload = {
+        short_urls: settings.short_urls ? false : undefined,
+        long_urls: settings.long_urls ? false : undefined,
+      };
     } else if (value === "long") {
-      updates.long_urls = true;
-
-      // fix legacy settings
-      if (settings.short_urls) {
-        updates.short_urls = false;
-      }
+      payload = {
+        long_urls: true,
+        short_urls: settings.short_urls ? false : undefined,
+      };
     }
 
-    const { success, error, data } = await makeRequest("PATCH", "/users/@me", {
-      settings: { ...updates },
+    // TODO: consildate request logic into one place to share with patchUser
+    const { success, error, data } = await makeRequest<SelfUser>("PATCH", "/users/@me", {
+      settings: payload,
     });
 
     if (!success || !data)

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -34,6 +34,7 @@ import { ModalProps } from "./base/modals";
 import { AnimatePresence, motion } from "framer-motion";
 import { permer } from "@imperial/commons";
 import { UserBadges } from "@web/utils/badge";
+import { DropdownItem } from "../Dropdown";
 
 const Wrapper = styled("div", {
   position: "relative",
@@ -468,6 +469,36 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
     setConfirmPassword("");
   };
 
+  const updateURLLength = (item: DropdownItem<"short" | "long" | "normal">) => {
+    const { value } = item;
+
+    // update to short urls.
+    if (value === "short") {
+      patchUser("short_urls", true);
+
+      // update legacy settings.
+      if (user.settings.long_urls) {
+        patchUser("long_urls", false);
+      }
+      // update to normal length urls.
+    } else if (value === "normal") {
+      if (user.settings.short_urls) {
+        patchUser("short_urls", false);
+      }
+
+      if (user.settings.long_urls) {
+        patchUser("long_urls", false);
+      }
+    } else if (value === "long") {
+      patchUser("long_urls", true);
+
+      // update legacy settings.
+      if (user.settings.short_urls) {
+        patchUser("short_urls", false);
+      }
+    }
+  };
+
   useEffect(() => {
     const fetchRecentDocuments = async () => {
       const { data, error, success } = await makeRequest<Document[]>(
@@ -726,18 +757,28 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
             onToggle={() => patchUser("clipboard", !user.settings.clipboard)}
           /> */}
           <Setting
-            title="Longer URLs"
-            type="switch"
-            toggled={user.settings.long_urls}
-            description="Create 32 character URLs."
-            onToggle={() => patchUser("long_urls", !user.settings.long_urls)}
-          />
-          <Setting
-            title="Short URLs"
-            type="switch"
-            toggled={user.settings.short_urls}
-            description="Create 4 character URLs."
-            onToggle={() => patchUser("short_urls", !user.settings.short_urls)}
+            title="URL Length"
+            description="Change the identifier length of the document."
+            type="dropdown"
+            items={[
+              {
+                value: "short",
+                title: "4 Characters",
+                selected: user.settings.short_urls === true,
+              },
+              {
+                value: "normal",
+                title: "8 Characters",
+                selected: !user.settings.short_urls && !user.settings.long_urls,
+              },
+              {
+                value: "long",
+                title: "32 Characters",
+                selected: user.settings.long_urls === true,
+              },
+            ]}
+            onSelect={updateURLLength}
+            minWidth={128}
           />
           <Setting
             title="Instant Delete"

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -474,9 +474,9 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
     const { value } = item;
     const settings = user.settings;
 
-    let payload: Pick<Partial<UserSettingsType>, "short_urls" | "long_urls"> = {};
+    let payload: Pick<Partial<UserSettingsType>, "short_urls" | "long_urls"> | undefined;
 
-    if (value === "short") {
+    if (value === "short" && !settings.short_urls) {
       payload = {
         short_urls: true,
         long_urls: settings.long_urls ? false : undefined,
@@ -486,11 +486,15 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
         short_urls: settings.short_urls ? false : undefined,
         long_urls: settings.long_urls ? false : undefined,
       };
-    } else if (value === "long") {
+    } else if (value === "long" && !settings.long_urls) {
       payload = {
         long_urls: true,
         short_urls: settings.short_urls ? false : undefined,
       };
+    }
+
+    if (!payload) {
+      return;
     }
 
     // TODO: consildate request logic into one place to share with patchUser

--- a/apps/web/src/components/modals/UserSettingsModal.tsx
+++ b/apps/web/src/components/modals/UserSettingsModal.tsx
@@ -481,7 +481,7 @@ function UserSettings({ user, dispatch, closeModal }: ReduxProps & ModalProps) {
         short_urls: true,
         long_urls: settings.long_urls ? false : undefined,
       };
-    } else if (value === "normal") {
+    } else if (value === "normal" && (settings.short_urls || settings.long_urls)) {
       payload = {
         short_urls: settings.short_urls ? false : undefined,
         long_urls: settings.long_urls ? false : undefined,


### PR DESCRIPTION
Switch from having two separate buttons for URL length to a singular dropdown menu.

There are currently 3 states the URL length can be in, `short`, `normal` and `long`. (4, 8, 32 characters respectively)
With having the old settings menu be switches we could enable having both short and long URLs where the short setting would override which made no sense, now our URL length can only be put into one state.

In the future I'm hoping this change also allows us to implement more URL lengths if needed.

![image](https://github.com/imperialbin/imperial/assets/49742865/9ac16a52-f482-4a71-bdc8-ebc1d08c572c)
