### PR TITLE
feat(api): allow for document settings to be inferred

### DIFF
--- a/apps/api/src/handlers/document/createDocument.ts
+++ b/apps/api/src/handlers/document/createDocument.ts
@@ -100,12 +100,16 @@ export const createDocument: FastifyImp<
   let { content } = body.data;
 
   let id: string;
-  // short id.
-  if (body.data.settings?.short_urls) id = documentIdGenerator(4);
-  // long id.
-  else if (body.data.settings?.long_urls) id = documentIdGenerator(36);
-  // normal id.
-  else id = documentIdGenerator(8);
+  // Short id.
+  if (body.data.settings?.short_urls) {
+    id = documentIdGenerator(4);
+    // Long id.
+  } else if (body.data.settings?.long_urls) {
+    id = documentIdGenerator(36);
+    // Normal id.
+  } else {
+    id = documentIdGenerator(8);
+  }
 
   // Encryption configuration
   const isMemberPlus = permer.test(request.user?.flags ?? 0, "member-plus");


### PR DESCRIPTION
Allow for a created document's settings to be inferred.
This feature will be especially useful for extensions to VSCode and Jetbrains so we don't need to fragment how settings are handled on each platform as currently Imperial works on **Web**, **VSCode** and **Jetbrains**. The main problem is how each platform will have different settings so if a user updates a setting in one place that change will not be reflected on all platforms.

We can now infer the user's settings so there is a single source of truth for a users settings. 🎉 